### PR TITLE
jsnext:main entry point for ES6 aware module bundlers

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-src
 webpack.conf.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
 webpack.conf.js
+.babelrc
+.eslintrc

--- a/package.json
+++ b/package.json
@@ -27,19 +27,19 @@
     "demo": "cpy ./lib/* ./demo"
   },
   "devDependencies": {
-    "babel": "6.3.13",
-    "babel-core": "6.1.18",
-    "babel-eslint": "4.1.3",
-    "babel-loader": "6.1.0",
+    "babel": "6.3.26",
+    "babel-core": "6.4.5",
+    "babel-eslint": "5.0.0-beta6",
+    "babel-loader": "6.2.1",
     "babel-plugin-add-module-exports": "0.1.2",
     "babel-preset-es2015": "6.3.13",
-    "chai": "3.4.1",
-    "cpy": "3.4.1",
-    "eslint": "1.7.2",
-    "eslint-loader": "1.1.0",
-    "mocha": "2.3.4",
-    "sinon": "1.17.2",
+    "chai": "3.5.0",
+    "cpy": "4.0.0",
+    "eslint": "1.10.3",
+    "eslint-loader": "1.2.1",
+    "mocha": "2.4.5",
+    "sinon": "1.17.3",
     "sinon-chai": "2.8.0",
-    "webpack": "1.12.9"
+    "webpack": "1.12.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "A simple vanilla JavaScript router with a fallback for older browsers",
   "main": "lib/navigo.js",
+  "jsnext:main": "src/index.js",
   "dependencies": {},
   "author": {
     "name": "Krasimir Tsonev",

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const FOLLOWED_BY_SLASH_REGEXP = '(?:\/|$)';
 function clean(s) {
   if (s instanceof RegExp) return s;
   return s.replace(/\/+$/, '').replace(/^\/+/, '/');
-};
+}
 
 function regExpResultToParams(match, names) {
   if (names.length === 0) return null;
@@ -19,7 +19,7 @@ function regExpResultToParams(match, names) {
       params[names[index]] = value;
       return params;
     }, null);
-};
+}
 
 function replaceDynamicURLParts(route) {
   var paramNames = [], regexp;
@@ -37,7 +37,7 @@ function replaceDynamicURLParts(route) {
     );
   }
   return { regexp, paramNames };
-};
+}
 
 function findMatchedRoutes(url, routes = []) {
   return routes
@@ -49,11 +49,11 @@ function findMatchedRoutes(url, routes = []) {
       return match ? { match, route, params } : false;
     })
     .filter(m => m);
-};
+}
 
 function match(url, routes) {
   return findMatchedRoutes(url, routes)[0] || false;
-};
+}
 
 function root(url, routes) {
   var matched = findMatchedRoutes(
@@ -74,7 +74,7 @@ function root(url, routes) {
       }, fallbackURL);
   }
   return fallbackURL;
-};
+}
 
 function Navigo(r, useHash) {
   this._routes = [];
@@ -85,7 +85,7 @@ function Navigo(r, useHash) {
     window.history.pushState
   );
   this._listen();
-};
+}
 
 Navigo.prototype = {
   helpers: {
@@ -143,7 +143,7 @@ Navigo.prototype = {
   },
   _listen: function () {
     if (this._ok) {
-      window.onpopstate = event => {
+      window.onpopstate = () => {
         this.resolve();
       };
     } else {


### PR DESCRIPTION
Hey,

I added jsnext:main entry point to package.json for ES6 module bundlers (rollup.js). Now we can use navigo without extra overhead. 

```javascript
import Navigo from 'navigo';
// code
```
and then share common utilities like babel runtime helpers with its code. To do this I had to remove src folder from npmignore ( also added babelrc and eslintrc to ignore). 

I also did some code cleaning, removed semicolons after function declarations and updated devDependencies and found one unused parameter event