### PR TITLE
http://xxxx/#/ is detected as a path param when useHash flag is true

### DIFF
--- a/demo/tests.js
+++ b/demo/tests.js
@@ -1,4 +1,5 @@
 var expect = chai.expect;
+var assert = chai.assert;
 
 var currentURL = function () {
   return window.location.href;
@@ -6,7 +7,6 @@ var currentURL = function () {
 var r;
 
 describe('Given Navigo library', function () {
-
   describe('when we give no routes and call the `resolve` method', function () {
     it('should return false', function () {
       r = new Navigo(root);
@@ -14,12 +14,16 @@ describe('Given Navigo library', function () {
     });  
   });
   describe('when we register routes', function () {
+    before(function () {
+      router.destroy();
+      router.navigate("");
+    });
     beforeEach(function () {
-      r = new Navigo(root);
+      r = new Navigo(root, true);
     });
     afterEach(function () {
       r.destroy();
-      r.navigate('testing');
+      r.navigate('');
     });
     it('should call the default handler', function (done) {
       r.on(function() {
@@ -57,6 +61,35 @@ describe('Given Navigo library', function () {
         done();
       });
       r.navigate('test-case/user/42');
+    });
+    it('should not detect hash as part of the navigation requirement', function (done) {
+        r.on({
+            "/:foo": function (params) {
+                assert.fail(true, false, "wrong handler is triggered when it shoud not be");
+                done();
+            },
+            "": function (params) {
+                assert(true, "correct handler is called");
+                done();
+            }
+        });
+      r.navigate('/');
+    });
+    it('should not detect hash as a param', function (done) {
+        r.on({
+            "/:foo/:bar": function (params) {
+                assert(true, "Correct handler is triggered");
+                assert(params.foo == "cat", params.foo + " value is returned");
+                assert(params.bar == "dog", params.bar + "Correct param value is returned");
+                done();
+            },
+            "/:foo/:bar/:baz": function (params) {
+                assert(false, "Wrong handler is triggered");
+                assert.isNotOk(params.foo == "#", "Wrong param value is returned");
+                done();
+            }
+        });
+      r.navigate("/cat/dog");
     });
   });
 });

--- a/lib/navigo.js
+++ b/lib/navigo.js
@@ -142,7 +142,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	
 	function Navigo(r, useHash) {
 	  this._routes = [];
-	  this.root = r || null;
+	  this.root = (useHash)? r.replace(/\/$/, "") + "/#": r || null;
 	  this._ok = !useHash && !!(typeof window !== 'undefined' && window.history && window.history.pushState);
 	  this._listen();
 	  this.updatePageLinks();


### PR DESCRIPTION
Fixed case where the useHash flag is on but the resolve function detects /#/ as a parameter given a route "/:pathParams"

Added "/#" to the root when the flag is true to resolve this issue