### PR TITLE
fixes #23 - link's href not updated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,11 +157,11 @@ Navigo.prototype = {
   updatePageLinks: function () {
     if (typeof document === 'undefined') return;
     this._findLinks().forEach(link => {
-      var location = link.getAttribute('href');
-
       link.addEventListener('click', e => {
         if (!this._destroyed) {
           e.preventDefault();
+          // get target's href attribute here, as it might be changed
+          var location = e.target.getAttribute("href");
           this.navigate(clean(location));
         }
       });


### PR DESCRIPTION
Link's href attribute was referenced during instantiation and link kept pointing to that url even if anchor's href was dynamically changed.

You can update tests if you want do - I didn't know how to run them nor I wanted to mess up the prettiness :)