### PR TITLE
Fix issue where listeners applied more than once

### DIFF
--- a/lib/navigo.js
+++ b/lib/navigo.js
@@ -222,12 +222,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	        link.addEventListener('click', function (e) {
 	          var location = link.getAttribute('href');
 	
-	          link.hasListenerAttached = true;
+	         
 	          if (!self._destroyed) {
 	            e.preventDefault();
 	            self.navigate(clean(location));
 	          }
 	        });
+	         link.hasListenerAttached = true;
 	      }
 	    });
 	  },


### PR DESCRIPTION
`link.hasListenerAttached` was being assigned inside of the event handler, which means that it was only set to true after the link is clicked. This means that you create a second listener on the event before finally setting `hasListenerAttached` to true. This breaks the back button. If we move the assignment outside the event handler, `hasListenerAttached` is immediately set to true, which fixes the problem.

Thanks for this excellent library. Light, simple, and effective.