### PR TITLE
Upgraded babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "babel": "6.3.26",
     "babel-core": "6.4.5",
-    "babel-eslint": "5.0.0-beta6",
+    "babel-eslint": "^6.1.2",
     "babel-loader": "6.2.1",
     "babel-plugin-add-module-exports": "0.1.2",
     "babel-preset-es2015": "6.3.13",


### PR DESCRIPTION
Ran into the following error when building locally:

```
TypeError: Cannot read property 'visitClass' of undefined
    at monkeypatch (/Users/.../code/navigo/node_modules/babel-eslint/index.js:220:40)
    at Object.exports.parse (/Users/.../code/navigo/node_modules/babel-eslint/index.js:362:5)
    at parse (/Users/.../code/navigo/node_modules/eslint/lib/eslint.js:512:27)
    at EventEmitter.module.exports.api.verify (/Users/.../code/navigo/node_modules/eslint/lib/eslint.js:646:19)
    at processText (/Users/.../code/navigo/node_modules/eslint/lib/cli-engine.js:230:27)
    at CLIEngine.executeOnText (/Users/.../code/navigo/node_modules/eslint/lib/cli-engine.js:686:26)
    at lint (/Users/.../code/navigo/node_modules/eslint-loader/index.js:25:20)
    at Object.module.exports (/Users/.../code/navigo/node_modules/eslint-loader/index.js:112:3)
    at WEBPACK_CORE_LOADER_EXECUTION (/Users/.../code/navigo/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:155:71)
    at runSyncOrAsync (/Users/.../code/navigo/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:155:93)
    at nextLoader (/Users/.../code/navigo/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:290:3)
    at /Users/.../code/navigo/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:259:5
    at Storage.finished (/Users/.../code/navigo/node_modules/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:16)
    at /Users/.../code/navigo/node_modules/webpack/node_modules/enhanced-resolve/node_modules/graceful-fs/graceful-fs.js:78:16
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
```

See: https://github.com/babel/babel-eslint/issues/243