### PR TITLE
Allows hook to prevent handler to be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,26 @@ router.on(
 );
 ```
 
+You may prevent the handler to be resolved in the `before` hook by invoking `done(false)`:
+
+```
+router.on(
+  '/user/edit',
+  function () {
+    // show user edit page
+  },
+  {
+    before: function (done) {
+      if(!user.loggedIn) {
+        done(false);
+      } else {
+        done()
+      }
+    }
+  }
+);
+```
+
 You may provide hooks in two other cases:
 
 * While specifying a main/root handler `router.on(function() { ... }, hooks)`

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,8 @@ function extractGETParameters(url) {
 function manageHooks(handler, route) {
   if (route && route.hooks && typeof route.hooks === 'object') {
     if (route.hooks.before) {
-      route.hooks.before(() => {
+      route.hooks.before((shouldRoute = true) => {
+        if (!shouldRoute) return;
         handler();
         route.hooks.after && route.hooks.after();
       });

--- a/test/spec/Navigo.spec.js
+++ b/test/spec/Navigo.spec.js
@@ -319,6 +319,19 @@ describe('Given an instance of Navigo', function () {
         beforeHook.callArg(0);
         expect(handler).to.be.calledOnce;
       });
+      it('should not call the handler if the before hook returns false', function() {
+        var beforeHook = sinon.spy(function(cb) {
+          cb(false)
+        });
+        var handler = sinon.spy();
+
+        router = new Navigo('http://site.com/', true);
+        router.on('/something', handler, { before: beforeHook });
+        router.resolve('/something');
+
+        expect(beforeHook).to.be.calledOnce;
+        expect(handler).to.not.be.called;
+      })
     });
     describe('and we provide only after hook', function () {
       it('should call after hook + the handler', function () {


### PR DESCRIPTION
This commit allows the `before` hook to prevent the handler to be resolved
by simply calling the `done` function by passing `false` as argument.

To get test running in my local machine I need to run `npm run build` and replace the `import Navigo from '../../lib/navigo';` by `import Navigo from '../../lib/navigo.min';` because somehow `lib/navigo.js` is not being updated in `npm run build`.

**Note:** This PR does not resolve #57 