### PR TITLE
Make sure we have a function when using named routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,12 @@ Navigo.prototype = {
       this._defaultHandler = { handler: args[0], hooks: args[1] };
     } else if (args.length >= 2) {
       if (args[0] === '/') {
-        this._defaultHandler = { handler: args[1], hooks: args[2] };
+        var func = args[1];
+        if (typeof args[1] === 'object') {
+          func = args[1].uses;
+        }
+
+        this._defaultHandler = { handler: func, hooks: args[2] };
       } else {
         this._add(args[0], args[1], args[2]);
       }


### PR DESCRIPTION
When using named routes the defaultHandler.handler must not be an object. 