### PR TITLE
Simplified regex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ Navigo.prototype = {
     } else if (typeof window !== 'undefined') {
       path = path.replace(/^#/, '');
       window.location.href =
-        window.location.href.replace(new RegExp('(#|' + this._hash + ')(.*)$'), '') + this._hash + path;
+        window.location.href.replace(new RegExp(this._hash + '.*$'), '') + this._hash + path;
     }
     return this;
   },


### PR DESCRIPTION
this._hash will be the same as "#" by default. If Im wrong, please provide a test that this improved regex will fail on. 