### PR TITLE
Send back target path for easier using navigo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -242,7 +242,7 @@ Navigo.prototype = {
       manageHooks(() => {
         m.route.route instanceof RegExp ?
           handler(...(m.match.slice(1, m.match.length))) :
-          handler(m.params, GETParameters);
+          handler(m.params, GETParameters, m.match[0]);
       }, m.route);
       return m;
     } else if (this._defaultHandler && (onlyURL === '' || onlyURL === '/' || onlyURL === this._hash)) {


### PR DESCRIPTION
When we catch a navigate event, and we want to do ajax call based on the catched url, and we use just some general route like /user/:action/:id in our rooter, then we need to know what was the originally catched url, without rebuild the original url from response parameters, query strings or without any hacky other solutions). I know this is not the most elegant way, but it doesn't break anything and better then nothing. In v5 navigo should send back an object with { params, query, targetPath } instead of 3 arguments.