### PR TITLE
Change for relative urls in navigation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -276,7 +276,7 @@ Navigo.prototype = {
     this._findLinks().forEach(link => {
       if (!link.hasListenerAttached) {
         link.addEventListener('click', function (e) {
-          var location = link.getAttribute('href');
+          var location = link.pathname;
 
           if (!self._destroyed) {
             e.preventDefault();


### PR DESCRIPTION
Pathname gives back exact route path even if the anchor has relative href.