### PR TITLE
Fixed root detection when defined routes include parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,11 @@ function match(url, routes) {
 
 function root(url, routes) {
   var matched = routes.map(
-    route => route.route === '' || route.route === '*' ? url : url.split(new RegExp(route.route + '($|\/)'))[0]
+    var regexp = new RegExp(route.route
+      .replace(Navigo.PARAMETER_REGEXP, Navigo.REPLACE_VARIABLE_REGEXP)
+      .replace(Navigo.WILDCARD_REGEXP, Navigo.REPLACE_WILDCARD) + '($|\/)');
+
+    route => route.route === '' || route.route === '*' ? url : url.split(regexp)[0]
   );
   var fallbackURL = clean(url);
 


### PR DESCRIPTION
Must transform routes with parameters into working regular expressions before calling **split()** during root detection (function **root()**).

I may have missed something, but I hope this will help you somehow...  Thanks!