### PR TITLE
Open in new tab when Ctrl-key is pressed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -318,6 +318,7 @@ Navigo.prototype = {
     this._findLinks().forEach(link => {
       if (!link.hasListenerAttached) {
         link.addEventListener('click', function (e) {
+          if((e.ctrlKey || e.metaKey) && e.target.tagName.toLowerCase() == 'a'){ return false; }
           var location = self.getLinkPath(link);
 
           if (!self._destroyed) {


### PR DESCRIPTION
Don't prevent the default browser behaviour when clicking on a <a>-tag with the ctrl-key pressed, so the link will open in a new tab.