### PR TITLE
Fix getCurrentURLPath error and provide ability for named regex group replacement in generate method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,7 @@ export type QContext = {
 };
 export type GenerateOptions = {
   includeRoot: boolean;
+  replaceRegexGroups: boolean;
 };
 export type RouterOptions = ResolveOptions & { linksSelector?: string };
 declare class Navigo {

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,7 +320,7 @@ export default function Navigo(appRoute?: string, options?: RouterOptions) {
 
             // Note that this won't handle regex groups that contain sub-groups
             // e.g. /(?<groupName>(:?example)?)
-            let keyRegex = new RegExp(`\(\?\<${regexEscapedKey}\>[^\(^\)]+\)`);
+            let keyRegex = new RegExp(`\\(\\?\\<${regexEscapedKey}\\>[^\\(^\\)]+\\)`, "g");
             result = result.replace(keyRegex, data[key]);
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,7 +312,19 @@ export default function Navigo(appRoute?: string, options?: RouterOptions) {
       if (data) {
         for (let key in data) {
           result = result.replace(":" + key, data[key]);
+
+          // If regex group replacement is enabled, search
+          // for named-regex parameter groups
+          if (options?.replaceRegexGroups === true) {
+            let regexEscapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+            // Note that this won't handle regex groups that contain sub-groups
+            // e.g. /(?<groupName>(:?example)?)
+            let keyRegex = new RegExp(`\(\?\<${regexEscapedKey}\>[^\(^\)]+\)`);
+            result = result.replace(keyRegex, data[key]);
+          }
         }
+
       }
       result = !result.match(/^\//) ? `/${result}` : result;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,11 +316,11 @@ export default function Navigo(appRoute?: string, options?: RouterOptions) {
           // If regex group replacement is enabled, search
           // for named-regex parameter groups
           if (options?.replaceRegexGroups === true) {
-            let regexEscapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const regexEscapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
             // Note that this won't handle regex groups that contain sub-groups
             // e.g. /(?<groupName>(:?example)?)
-            let keyRegex = new RegExp(`\\(\\?\\<${regexEscapedKey}\\>[^\\(^\\)]+\\)`, "g");
+            const keyRegex = new RegExp(`\\(\\?\\<${regexEscapedKey}\\>[^\\(^\\)]+\\)`, "g");
             result = result.replace(keyRegex, data[key]);
           }
         }

--- a/src/middlewares/setLocationPath.ts
+++ b/src/middlewares/setLocationPath.ts
@@ -1,15 +1,14 @@
 import { QContext } from "../../index";
 import { getCurrentEnvURL } from "../utils";
 
-export default function setLocationPath(context: QContext, done: () => void): void {
-  
-  const { currentLocationPath, instance } = context;
-  
-  if (typeof currentLocationPath === "undefined") {
-    context.currentLocationPath = context.to = getCurrentURLPath(instance.root);
+export default function setLocationPath(context: QContext, done) {
+  if (typeof context.currentLocationPath === "undefined") {
+    context.currentLocationPath = context.to = getCurrentEnvURL(
+      context.instance.root
+    );
   }
-  
-  context.currentLocationPath = instance._checkForAHash(currentLocationPath);
-  
+  context.currentLocationPath = context.instance._checkForAHash(
+    context.currentLocationPath
+  );
   done();
 }


### PR DESCRIPTION
Reverted 0aed88e as this was causing errors, both in tests and in real usage:
```
Uncaught ReferenceError: getCurrentURLPath is not defined
```

Added ability to replace regex groups (that are using named regex groups) in path, e.g:

```
    router.on({
        '/example/(?<name>.*)': {
            as: "TestRoute",
            uses: function ({ data }) { }
        }
    });

    router.generate('TestRoute', {name: 'myname'}, {replaceRegexGroups: true})
    > '/example/myname'
```

Disclaimer: I'm not too used to npm/yarn and how builds are generally performed for this type of project - I had to do some mangling to be able to build (during which some packages got updated), so I didn't include in this PR, but have committed them to https://github.com/MatthewJohn/navigo/tree/fix-build - apologies in advance!